### PR TITLE
Add service route tests

### DIFF
--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -9,6 +9,7 @@
     "deploy": "wrangler deploy -e production",
     "dev": "wrangler dev --port 8788",
     "start": "wrangler dev",
+    "test": "vitest run",
     "cf-typegen": "wrangler types",
     "format": "biome format --write ./src",
     "lint": "biome lint --write ./src",
@@ -29,6 +30,7 @@
     "@types/node": "22.13.0",
     "@types/qrcode-svg": "^1.1.5",
     "@types/service-worker-mock": "^2.0.4",
+    "vitest": "~3.2.0",
     "wrangler": "^4.69.0"
   }
 }

--- a/packages/service/src/repository/repository.ts
+++ b/packages/service/src/repository/repository.ts
@@ -17,7 +17,7 @@ export const getShortlinkBySlug = async (
 	slug: string,
 ): Promise<ShortlinkDomain> => {
 	const res = await c.env.DB.prepare(
-		"SELECT s.url FROM shortlinks s WHERE s.slug = ?",
+		"SELECT s.url, s.isPermanent FROM shortlinks s WHERE s.slug = ?",
 	)
 		.bind(slug)
 		.first<{ url: string; isPermanent: number }>();

--- a/packages/service/test/service.test.ts
+++ b/packages/service/test/service.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import app from "../src/index";
+import { getShortlinkBySlug } from "../src/repository/repository";
+
+type ShortlinkRow = {
+	url: string;
+	isPermanent: number;
+};
+
+function createDb(
+	rows: Record<string, ShortlinkRow>,
+	onPrepare?: (sql: string) => void,
+) {
+	return {
+		prepare(sql: string) {
+			onPrepare?.(sql);
+			return {
+				bind(slug: string) {
+					return {
+						first: async () => rows[slug] ?? null,
+					};
+				},
+			};
+		},
+	};
+}
+
+function createEnv(
+	rows: Record<string, ShortlinkRow> = {},
+	overrides: Partial<Env> = {},
+): Env {
+	return {
+		DB: createDb(rows) as unknown as D1Database,
+		ENVIRONMENT: "development",
+		SHORTER_API_KEY: "test-api-key",
+		...overrides,
+	} as Env;
+}
+
+describe("shorter service", () => {
+	it("requires bearer auth on protected routes in production", async () => {
+		const response = await app.request(
+			"/_links/example",
+			undefined,
+			createEnv({}, { ENVIRONMENT: "production" }),
+		);
+
+		expect(response.status).toBe(401);
+	});
+
+	it("redirects temporary links with HTTP 302", async () => {
+		const response = await app.request(
+			"/temp-link",
+			undefined,
+			createEnv({
+				"temp-link": {
+					url: "https://example.com/temporary",
+					isPermanent: 0,
+				},
+			}),
+		);
+
+		expect(response.status).toBe(302);
+		expect(response.headers.get("Location")).toBe("https://example.com/temporary");
+	});
+
+	it("redirects permanent links with HTTP 301", async () => {
+		const response = await app.request(
+			"/perm-link",
+			undefined,
+			createEnv({
+				"perm-link": {
+					url: "https://example.com/permanent",
+					isPermanent: 1,
+				},
+			}),
+		);
+
+		expect(response.status).toBe(301);
+		expect(response.headers.get("Location")).toBe("https://example.com/permanent");
+	});
+
+	it("returns an SVG QR code for an existing shortlink", async () => {
+		const response = await app.request(
+			"/qr-link.svg",
+			undefined,
+			createEnv({
+				"qr-link": {
+					url: "https://example.com/qr-target",
+					isPermanent: 0,
+				},
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(response.headers.get("Content-Type")).toContain("image/svg+xml");
+		expect(await response.text()).toContain("<svg");
+	});
+
+	it("returns a 404 payload for unknown slugs", async () => {
+		const response = await app.request("/missing-link", undefined, createEnv());
+
+		expect(response.status).toBe(404);
+		await expect(response.json()).resolves.toEqual({
+			success: false,
+			error: "Slug not found",
+		});
+	});
+
+	it("queries the permanence flag and coerces it to a boolean", async () => {
+		let preparedSql = "";
+		const context = {
+			env: {
+				DB: createDb(
+					{
+						repository: {
+							url: "https://example.com/from-repository",
+							isPermanent: 1,
+						},
+					},
+					(sql) => {
+						preparedSql = sql;
+					},
+				) as unknown as D1Database,
+			},
+		};
+
+		const shortlink = await getShortlinkBySlug(context as never, "repository");
+
+		expect(preparedSql).toContain("isPermanent");
+		expect(shortlink).toEqual({
+			url: "https://example.com/from-repository",
+			isPermanent: true,
+		});
+	});
+});

--- a/packages/service/vitest.config.ts
+++ b/packages/service/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		include: ["test/**/*.test.ts"],
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@types/service-worker-mock':
         specifier: ^2.0.4
         version: 2.0.4
+      vitest:
+        specifier: ~3.2.0
+        version: 3.2.4(@types/node@22.13.0)(yaml@2.8.2)
       wrangler:
         specifier: ^4.69.0
         version: 4.69.0


### PR DESCRIPTION
## Summary
- add a Vitest setup for the service package
- add focused tests for auth, redirects, QR responses, and missing slugs
- fix shortlink lookup to select `isPermanent` so permanent redirects return 301

## Verification
- pnpm --filter @shorter2/service test
- pnpm --filter @shorter2/service typecheck